### PR TITLE
Suppress error messages in a certain condition

### DIFF
--- a/autoload/qfreplace.vim
+++ b/autoload/qfreplace.vim
@@ -68,9 +68,14 @@ function! s:do_replace()
     endif
     if e.text !=# new_text
       if getline(e.lnum) !=# s:chomp(e.text)
-        call s:echoerr(printf(
-        \  'qfreplace: Original text has changed: %s:%d',
-        \   bufname(e.bufnr), e.lnum))
+        if getline(e.lnum) ==# new_text
+          " Original text has changed, but the changed one is equal to
+          " `new_text`. It is not an error.
+        else
+          call s:echoerr(printf(
+          \  'qfreplace: Original text has changed: %s:%d',
+          \   bufname(e.bufnr), e.lnum))
+        endif
       else
         call setline(e.lnum, new_text)
         let e.text = new_text


### PR DESCRIPTION
# Description

This change is for suppressing error messages reported when trying to perform the same replacement against the same line.

When a line has several same words, some grep tools like `ripgrep` generate multiple QuickFix entries for each match.

Example:

File (a.txt):
```
foo foo foo
```

Command result:
```
$ rg --vimgrep foo  # Run ripgrep command with --vimgrep flag
a.txt:1:1:foo foo foo
a.txt:1:5:foo foo foo
a.txt:1:9:foo foo foo
```

When you replace all "foo" with "bar" in `qfreplace` buffer and write the buffer, `qfreplace` reports error: "qfreplace: Original text has changed". However, it is a false positive error.